### PR TITLE
Add command for toggling checkbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,25 @@ This Sublime Package provides syntax-highlighting, shortcuts, and auto-completio
 ### Keybindings for Commands
 
 The following commands are available for you to put into your `Default.sublime-keymap` file.
+The key combination is up to you, of course.
 
 ```js
 [
-	// Toggle item status to checked [x]
+	// Toggle checkbox status of the item.
+	// It cycles through the statuses given in the
+	// `xit_toggle` setting.
+	{ "keys": ["ctrl+shift+t"], "command": "xit_toggle" },
+
+	// Set item status to checked [x]
 	{ "keys": ["ctrl+shift+x"], "command": "xit_check" },
 	
-	// Toggle item status to open [ ]
+	// Set item status to open [ ]
 	{ "keys": ["ctrl+shift+o"], "command": "xit_open" },
 
-	// Toggle item status to ongoing [@]
+	// Set item status to ongoing [@]
 	{ "keys": ["ctrl+shift+a"], "command": "xit_ongoing" },
 
-	// Toggle item status to obsolete [~]
+	// Set item status to obsolete [~]
 	{ "keys": ["ctrl+shift+n"], "command": "xit_obsolete" },
 ]
 ```
@@ -38,12 +44,16 @@ The following commands are available for you to put into your `Default.sublime-k
 ### Settings (Syntax Specific)
 
 The following settings can be overriden via your syntax-specific `xit.sublime-settings` file.
+The values are the default ones.
 
 ```js
 {
 	// Auto-save after toggling checkboxes (via the commands `xit_check`, etc.).
-	// Default: true
 	"xit_auto_save": true,
+
+	// The checkbox statuses that the `xit_toggle` command
+	// should cycle through.
+	"xit_toggle": ["[ ]", "[x]"],
 }
 ```
 

--- a/xit.sublime-commands
+++ b/xit.sublime-commands
@@ -20,5 +20,8 @@
   }, {
     "caption": "[x]it!: Mark Item As Obsolete",
     "command": "xit_obsolete"
-  },
+  }, {
+    "caption": "[x]it!: Toggle Item Status",
+    "command": "xit_toggle"
+  }
 ]

--- a/xit.sublime-settings
+++ b/xit.sublime-settings
@@ -2,6 +2,9 @@
 	// Auto-save after toggling checkboxes from the command palette.
 	"xit_auto_save": true,
 
+	// The checkbox statuses that the `xit_toggle` command cycles through.
+	"xit_toggle": ["[ ]", "[x]"],
+
 	// Always open [x]it! files with a specific theme.
 	// For Monokai and Mariana, there is language-specific
 	// syntax highlighting.


### PR DESCRIPTION
Resolves https://github.com/jotaen/xit-sublime/issues/4.

## Summary
Add new command `xit_toggle` that toggles the status of a checkbox. By default, it toggles between `[ ]` and `[x]`, but the sequence can be customised via the `xit_toggle` setting.