### PR TITLE
Modfied the due date regex

### DIFF
--- a/xit.sublime-syntax
+++ b/xit.sublime-syntax
@@ -80,7 +80,7 @@ contexts:
         pop: 3
 
       # Due dates.
-      - match: '-> (\d{4}(([-/]\d{2}([-/]\d{2}?)?)|([-/]W\d{2}))?)(?![-/])(?=[\p{P} ]|$)'
+      - match: '-> ((19[7-9]\d|20\d{2})(([-/](0?[1-9]|1[0-2])([-/](0?[1-9]|[1-2]\d|3[0-1])?)?)|([-/](W(0?[1-9]|[1-4]\d|5[0-3])|Q[1-4])))?)(?![-/])(?=[\p{P} ]|$)'
         scope: storage.type.xit markup.other.due_date.xit
 
       # Tags. (The `match: ...` can’t be quoted!)

--- a/xit.sublime-syntax
+++ b/xit.sublime-syntax
@@ -83,7 +83,7 @@ contexts:
       # Added a few sanity checks (1969 < yyyy < 2100, mm < 13, dd < 32, ww < 53.)
       # Added Q1-Q4, which were missing. Made leading zeroes optional. 
       # Allow either / or - in dates, but not both
-      - match: '-> ((19[7-9]\d|20\d{2})((([-/])(0?[1-9]|1[0-2])(\5(0?[1-9]|[1-2]\d|3[0-1])?)?)|(\5(W(0?[1-9]|[1-4]\d|5[0-3])|Q[1-4])))?)(?!\5)(?=[\p{P} ]|$)'
+      - match: '-> ((19[7-9]\d|20\d{2})((([-/])(0?[1-9]|1[0-2])(\5(0?[1-9]|[1-2]\d|3[0-1])?)?)|(\5(W(0?[1-9]|[1-4]\d|5[0-3])|Q[1-4])))?)(?![-/])(?=[\p{P} ]|$)'
         scope: storage.type.xit markup.other.due_date.xit
 
       # Tags. (The `match: ...` can’t be quoted!)

--- a/xit.sublime-syntax
+++ b/xit.sublime-syntax
@@ -79,7 +79,9 @@ contexts:
       - match: '^(?!    )'
         pop: 3
 
-      # Due dates.
+      # Due dates. 
+      # Added a few sanity checks (1969 < yyyy < 2100, mm < 13, dd < 32, ww < 53.)
+      # Added Q1-Q4, which were missing. Made leading zeroes optional. 
       - match: '-> ((19[7-9]\d|20\d{2})(([-/](0?[1-9]|1[0-2])([-/](0?[1-9]|[1-2]\d|3[0-1])?)?)|([-/](W(0?[1-9]|[1-4]\d|5[0-3])|Q[1-4])))?)(?![-/])(?=[\p{P} ]|$)'
         scope: storage.type.xit markup.other.due_date.xit
 

--- a/xit.sublime-syntax
+++ b/xit.sublime-syntax
@@ -80,10 +80,9 @@ contexts:
         pop: 3
 
       # Due dates. 
-      # Added a few sanity checks (1969 < yyyy < 2100, mm < 13, dd < 32, ww < 53.)
-      # Added Q1-Q4, which were missing. Made leading zeroes optional. 
-      # Allow either / or - in dates, but not both
-      - match: '-> ((19[7-9]\d|20\d{2})((([-/])(0?[1-9]|1[0-2])(\5(0?[1-9]|[1-2]\d|3[0-1])?)?)|([-/](W(0?[1-9]|[1-4]\d|5[0-3])|Q[1-4])))?)(?![-/])(?=[\p{P} ]|$)'
+      # It applies basic static sanity checks on the dates, but it can’t
+      # enforce valid calendar dates.
+      - match: '-> ((\d{4})((([-/])(0[1-9]|1[0-2])(\5(0[1-9]|[1-2]\d|3[0-1])?)?)|([-/](W(0[1-9]|[1-4]\d|5[0-3])|Q[1-4])))?)(?![-/])(?=[\p{P} ]|$)'
         scope: storage.type.xit markup.other.due_date.xit
 
       # Tags. (The `match: ...` can’t be quoted!)

--- a/xit.sublime-syntax
+++ b/xit.sublime-syntax
@@ -82,7 +82,8 @@ contexts:
       # Due dates. 
       # Added a few sanity checks (1969 < yyyy < 2100, mm < 13, dd < 32, ww < 53.)
       # Added Q1-Q4, which were missing. Made leading zeroes optional. 
-      - match: '-> ((19[7-9]\d|20\d{2})(([-/](0?[1-9]|1[0-2])([-/](0?[1-9]|[1-2]\d|3[0-1])?)?)|([-/](W(0?[1-9]|[1-4]\d|5[0-3])|Q[1-4])))?)(?![-/])(?=[\p{P} ]|$)'
+      # Allow either / or - in dates, but not both
+      - match: '-> ((19[7-9]\d|20\d{2})((([-/])(0?[1-9]|1[0-2])(\5(0?[1-9]|[1-2]\d|3[0-1])?)?)|(\5(W(0?[1-9]|[1-4]\d|5[0-3])|Q[1-4])))?)(?!\5)(?=[\p{P} ]|$)'
         scope: storage.type.xit markup.other.due_date.xit
 
       # Tags. (The `match: ...` can’t be quoted!)

--- a/xit.sublime-syntax
+++ b/xit.sublime-syntax
@@ -83,7 +83,7 @@ contexts:
       # Added a few sanity checks (1969 < yyyy < 2100, mm < 13, dd < 32, ww < 53.)
       # Added Q1-Q4, which were missing. Made leading zeroes optional. 
       # Allow either / or - in dates, but not both
-      - match: '-> ((19[7-9]\d|20\d{2})((([-/])(0?[1-9]|1[0-2])(\5(0?[1-9]|[1-2]\d|3[0-1])?)?)|(\5(W(0?[1-9]|[1-4]\d|5[0-3])|Q[1-4])))?)(?![-/])(?=[\p{P} ]|$)'
+      - match: '-> ((19[7-9]\d|20\d{2})((([-/])(0?[1-9]|1[0-2])(\5(0?[1-9]|[1-2]\d|3[0-1])?)?)|([-/](W(0?[1-9]|[1-4]\d|5[0-3])|Q[1-4])))?)(?![-/])(?=[\p{P} ]|$)'
         scope: storage.type.xit markup.other.due_date.xit
 
       # Tags. (The `match: ...` can’t be quoted!)


### PR DESCRIPTION
Hi!

I have played with `xit!` for Sublime a bit, and discovered that the due dates had no syntax support for Q1/Q2/Q3/Q4 yet. I have taken the liberty to add that. 

While I was taking a stab at the regex, I also made leading zeros optional, so a date like `2022-5-1` would be simply read as `2022-05-01`. (Not sure if this actually violates the specs, but I think it's convenient.)

I also added some sanity checks: Months must be 1-12, days 1-31, week numbers 1-53, quarters 1-4. This should catch most invalid dates, if not all of them. The limit I placed on years is somewhat arbitrary, although 1970-2100 should work for most cases. I finally disallowed mixing slashes and hyphens in dates, it's either one or the other.

Feel free to use as much or as little of my suggestions as you want; it's working fine locally. 

Take care, Ingmar